### PR TITLE
Fix LinkedIn link to permalink listed on profile.

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
         </p>
         <p class="f4 book sans-serif"> 
           <a class="link" href="https://github.com/bak">GitHub</a>,
-          <a class="link" href="https://www.linkedin.com/e/fpf/9155288">LinkedIn</a>,
+          <a class="link" href="https://www.linkedin.com/in/beancuke">LinkedIn</a>,
           <a class="link" href="https://twitter.com/beancuke">Twitter</a>
         </p>
         <p class="f4 book sans-serif">


### PR DESCRIPTION
The previous link was 404ing I'm guessing due to a link structure change
they didn't preserve bc. This one claims to be a perma-link, but at the
very least is working.
